### PR TITLE
[Added] Add convert_video Feature to CLI

### DIFF
--- a/oraculo/cli.py
+++ b/oraculo/cli.py
@@ -239,6 +239,37 @@ def test():
         metadata={"collection_name": "teste"},
     )
 
+@app.command(help="Converts files with different video formats to .mp4")
+def convert_video(bulk : Annotated[bool, typer.Option(help="Converts all files with video extensions in a folder")] = False, output_directory : Annotated[str, typer.Option(help="Output folder path")] = None):
+
+    if bulk:
+        path_str = typer.prompt("Source Directory Path: ", default=None)
+        path = Path(path_str)
+        audio_extensions = ['mp3', 'wav', 'm4a', 'flac', 'mp4', 'mkv', 'avi']
+        files = [f for ext in audio_extensions for f in path.glob(f'*.{ext}')]
+
+        if output_directory is None:
+            output = path
+        else:
+            output = Path(output_directory)
+
+        for file in track(files, "Converting... :hourglass:"):
+            filename = file.stem
+            output_file = output / f"{filename}.mp4"
+            print(f"Converting {filename}...")
+            subprocess.run(["ffmpeg", "-i", file, output_file])
+    else:
+        path_str = typer.prompt("Source File Path: ", default=None)
+        path = Path(path_str)
+        if output_directory is None:
+            output = path.parent
+        else:
+            output = Path(output_directory)
+        filename = path.stem
+        output_file = output / f"{filename}.mp4"
+        print(f"Converting {filename}...")
+        subprocess.run(["ffmpeg", "-i", path, output_file])
+
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
# Title:
Add convert_video Feature to CLI

# Description:
**What does this PR do?**
This Pull Request introduces a new command to the CLI tool, called convert_video. The command allows users to convert files from various video formats to the .mp4 format. It also supports bulk conversion of video files within a folder.

## How should this be manually tested?
- Checkout to the feature/convert_video branch.
- Run the CLI tool with the new convert_video command.
- For single file conversion: 
```bash
oraculo convert_video --output-directory <output-directory-path>
```
- For bulk conversion: 
```bash
oraculo convert_video --bulk --output-directory <output-directory-path>
```

Verify that the video files are converted and saved in the specified output_directory, defaulting to the source directory if not provided.

Extensions: `mp3`, `wav`, `m4a`, `flac`, `mp4`, `mkv`, `avi`

The feature leverages the FFmpeg library for video conversion, thus requiring the user to have FFmpeg installed on their machine.

## What are the relevant issues?
If applicable, link any relevant issues here.

## Additional Notes:
This feature adds a new dependency: FFmpeg must be installed for the conversion to work.

## Checklist:
 I have tested my changes manually
 I have updated the documentation accordingly (if needed)
 My changes generate no new warnings